### PR TITLE
allow to build different source tar.gz for same version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ run the following command to install depedencies:
 apt-get install devscripts
 ```
 
+## Update Package
+
+To rebuild the package on different Debian version, increase the patch version
+(X.X.1 --> X.X.2)
+Otherwise, the builder (get-orig-source) can produce a different .tar.gz file size and md5
+
 ## Build Package
 
 To download sources and build package, execute:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asterisk-moh-opsound (2.03.1-1~wazo1) wazo-dev-buster; urgency=medium
+
+  * Add patch version to build source from different debian version
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Thu, 09 Mar 2023 14:21:47 -0500
+
 asterisk-moh-opsound (2.03-2~wazo2) wazo-dev-buster; urgency=medium
 
   * Improve packaging and add Jenkinsfile

--- a/debian/rules
+++ b/debian/rules
@@ -2,12 +2,18 @@
 
 BASE_URL=http://downloads.asterisk.org/pub/telephony/sounds/releases/
 PACKAGE=$(shell sed -e '2,$$d' -e 's/ .*//' debian/changelog)
-VERSION=$(shell sed -e '2,$$d' -e 's/^[^(]*(\([^-]*\)-.*)*)*/\1/' debian/changelog)
+VERSION=$(shell sed -e '2,$$d' -e 's/^[^(]*(\([^-]*\)-.*)*)*/\1/' debian/changelog |  cut -f 1,2 -d '.')
+# Because source package is not downloaded, but built by the get-orig-source
+# target which can be on different Debian version (and different tar version),
+# the .tar.gz can have different size/md5
+# Adding a patch version to the original versioning allow to rebuild same
+# version on different OS and have different source package
+FAKE_VERSION=$(shell sed -e '2,$$d' -e 's/^[^(]*(\([^-]*\)-.*)*)*/\1/' debian/changelog)
 TMPDIR=tmp
 FORMATS=gsm g722 wav
 TARGET_DIR=..
 
-PKGNAME=$(PACKAGE)-$(VERSION)
+PKGNAME=$(PACKAGE)-$(FAKE_VERSION)
 PKGDIR=$(TMPDIR)/$(PKGNAME)
 
 %:
@@ -16,7 +22,7 @@ PKGDIR=$(TMPDIR)/$(PKGNAME)
 
 print-version:
 	@echo package: $(PACKAGE)
-	@echo version: $(VERSION)
+	@echo version: $(FAKE_VERSION)
 
 get-orig-source:
 	rm -rf $(PKGDIR)
@@ -36,6 +42,6 @@ get-orig-source:
 	  tarball="$(PACKAGE)-$$format-$(VERSION).tar.gz"; \
 	  $(RM) -f $$tarball; \
 	 done
-	tar czf $(TARGET_DIR)/$(PACKAGE)_$(VERSION).orig.tar.gz \
-		-C $(TMPDIR) $(PACKAGE)-$(VERSION)
+	tar czf $(TARGET_DIR)/$(PACKAGE)_$(FAKE_VERSION).orig.tar.gz \
+		-C $(TMPDIR) $(PACKAGE)-$(FAKE_VERSION)
 	rm -rf $(TMPDIR)


### PR DESCRIPTION
why: since the source tar.gz can be different according the debian
version, we add a patch version to the versionning to avoid conflict